### PR TITLE
Add note about workers

### DIFF
--- a/docs/getstarted/how_to_deploy_an_app.md
+++ b/docs/getstarted/how_to_deploy_an_app.md
@@ -44,7 +44,7 @@ Ninefold has 4 app infrastructure choices:
 
 We will initially set __RAILS_ENV=production__ regardless of what setup is chosen. This setting can be changed in the next step.
 
-If a worker is chosen (dedicated or not), we will automatically install Redis.
+If a worker is chosen (dedicated or not), we will automatically install Redis. Please note that if you do not choose a worker during this initial setup process, it cannot be added later.
 
 #### 3 Details
 


### PR DESCRIPTION
@Brit200313 was helping me setup my first ninefold server today. My app is in its very early stages and doesn't have any workers yet but I know that it will eventually. One thing that came up during the setup process was that if I said no to background workers during the setup phase, I wouldn't be able to add them later. This isn't a big deal and there might be a better way to phrase it (if you do in fact decide to include it in the docs) but I figured I'd open a PR as it might be helpful to other users following along in the docs while setting up their servers.
